### PR TITLE
Add support for Neovim

### DIFF
--- a/plugin/os-unittestr.vim
+++ b/plugin/os-unittestr.vim
@@ -210,7 +210,16 @@ function! s:Run_tox_test(...)
   else
     let l:env = a:1
   endif
-  call term_start(['tox', '-e', l:env, s:get_test_full_path()])
+  if has('nvim')
+    let l:path = s:get_test_full_path()
+    wincmd n
+    setlocal nonumber norelativenumber signcolumn=no listchars=
+    setlocal nocursorcolumn nocursorline
+    call termopen(['tox', '-e', l:env, l:path])
+    startinsert
+  else
+    call term_start(['tox', '-e', l:env, s:get_test_full_path()])
+  endif
 endfunction
 
 " Shortcuts to lunch the feature.


### PR DESCRIPTION
Although the current plugin uses the function `term_start` to run a
command, this function isn't available on Neovim.

Changed to use the function `termopen` instead if an editor is Neovim,
otherwise `term_start` is called as before.  To disable unnecessary
prints in the Neovim terminal, some local options are changed.  Also, as
the `termopen` opens a new terminal in the current buffer, `wincmd` is
called in advance to split a window vertically.